### PR TITLE
Fix pydantic protected namespace warning

### DIFF
--- a/src/config_models.py
+++ b/src/config_models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from typing import List, Dict, Optional, Any
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 class FeaturesConfig(BaseModel):
     numeric: List[str]
@@ -31,6 +31,8 @@ class DataConfig(BaseModel):
 
 class TrainingConfig(BaseModel):
     """Configuration for model training."""
+
+    model_config = ConfigDict(protected_namespaces=("model_validate",))
 
     k_folds: int = 5
     random_seed: int = 42


### PR DESCRIPTION
## Summary
- adjust `TrainingConfig` in `config_models.py` to avoid Pydantic protected namespace warning

## Testing
- `uv sync`
- `uv run -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868fe22f9a083338318bf8b581b1117