### PR TITLE
Add modular workflow helpers

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -82,9 +82,12 @@ evaluation:
     - revenue_per_contact
     - acceptance_rate
     - roi
+  cost_per_contact: 1.0
 
 inference:
   output_dir: "../data/inference"
+  propensity_file: "propensity_predictions.csv"
+  revenue_file: "revenue_predictions.csv"
 
 training:
   k_folds: 5

--- a/src/config_models.py
+++ b/src/config_models.py
@@ -53,7 +53,11 @@ class MlflowConfig(BaseModel):
 class InferenceConfig(BaseModel):
     """Configuration for inference output."""
 
+    model_config = ConfigDict(extra="ignore")
+
     output_dir: str = "../data/inference"
+    propensity_file: str = "propensity_predictions.csv"
+    revenue_file: str = "revenue_predictions.csv"
 
 class ConfigSchema(BaseModel):
     data: DataConfig


### PR DESCRIPTION
## Summary
- add filenames and cost configuration to `config.yaml`
- ignore extras in `InferenceConfig` and include file names
- refactor main workflow with `run_inference`, `run_optimization`, and helper functions

## Testing
- `PYTHONPATH=. uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a54470fe883339749ae26cc896fd0