### PR TITLE
Add informative logging to main workflow

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,6 +14,10 @@ from src.model_loader import ModelLoader
 from src.optimizer import Optimizer
 from src.preprocessor import Preprocessor
 from src.trainer import PropensityTrainer, RevenueTrainer
+from src.logging import get_logger, setup_logging
+
+setup_logging()
+logger = get_logger(__name__)
 
 import numpy as np
 import pandas as pd
@@ -27,6 +31,7 @@ def run_inference(
     config_dict: dict,
 ) -> tuple[pd.DataFrame, pd.DataFrame, pd.Index]:
     """Run propensity and revenue inference."""
+    logger.info("Merging datasets for inference")
     inference_df = preprocessor.merge_datasets(
         datasets, base_dataset_key="Sales_Revenues"
     )
@@ -34,11 +39,13 @@ def run_inference(
     X_inf = inference_df[numeric + categorical]
     X_inf.index = inference_df["Client"]
 
+    logger.info("Running propensity and revenue inference")
     prop_inf = PropensityInference(config=config_dict)
     rev_inf = RevenueInference(config=config_dict)
     prop_preds = prop_inf.predict(X_inf)
     rev_preds = rev_inf.predict(X_inf)
 
+    logger.info("Saving inference results")
     prop_inf.save(prop_preds, cfg.inference.propensity_file)
     rev_inf.save(rev_preds, cfg.inference.revenue_file)
     return prop_preds, rev_preds, X_inf.index
@@ -48,6 +55,7 @@ def run_optimization(
     cfg: DictConfig, prop_preds: pd.DataFrame, rev_preds: pd.DataFrame
 ) -> np.ndarray:
     """Optimize the marketing offers."""
+    logger.info("Running optimization")
     expected = prop_preds.values * rev_preds.values
     optimizer = Optimizer(contact_limit=cfg.optimization.contact_limit)
     return optimizer.solve(expected)
@@ -61,12 +69,13 @@ def run_evaluation(
     config_dict: dict,
 ) -> dict:
     """Evaluate optimized offers using configured metrics."""
+    logger.info("Evaluating optimization results")
     evaluator = Evaluator(
         config=config_dict, cost_per_contact=cfg.evaluation.cost_per_contact
     )
     results = evaluator.evaluate(selection, prop_preds.values, rev_preds.values)
     for name, value in results.items():
-        print(f"{name}: {value:.4f}")
+        logger.info("%s: %.4f", name, value)
     return results
 
 
@@ -78,6 +87,7 @@ def save_offers(
     client_index: pd.Index,
 ) -> pd.DataFrame:
     """Persist the optimized offer list to disk."""
+    logger.info("Saving optimized offers")
     selection_df = pd.DataFrame(selection, index=client_index, columns=cfg.products)
     result_rows = []
     for product in cfg.products:
@@ -90,7 +100,9 @@ def save_offers(
                     "expected_revenue": rev_preds.loc[
                         mask, f"expected_revenue_{product}"
                     ].values,
-                    "probability": prop_preds.loc[mask, f"probability_{product}"].values,
+                    "probability": prop_preds.loc[
+                        mask, f"probability_{product}"
+                    ].values,
                 }
             )
             result_rows.append(df_sel)
@@ -104,26 +116,42 @@ def save_offers(
 
 @hydra.main(config_path="conf/", config_name="config")
 def main(cfg: DictConfig) -> None:
+    logger.info("Starting main workflow")
     config_dict = OmegaConf.to_container(cfg, resolve=True)
     loader = DataLoader(config=config_dict)
     loader.config_loader.base_dir = os.path.join(get_original_cwd(), "conf")
 
+    logger.info("Loading datasets")
     datasets = loader.load_configured_sheets()
     with_sales, _ = loader.create_sales_data_split(datasets)
+    logger.info("Created sales data split")
     preprocessor = Preprocessor(loader.get_config())
     train_sets, _ = preprocessor.create_model_train_test_split(
         with_sales, test_size=0.2, random_state=cfg.training.random_seed
     )
-    merged = preprocessor.merge_datasets(train_sets, base_dataset_key="Sales_Revenues_train")
+    logger.info("Created train/test split")
+    merged = preprocessor.merge_datasets(
+        train_sets, base_dataset_key="Sales_Revenues_train"
+    )
+    logger.info("Merged training datasets")
     if cfg.training.sample_fraction < 1.0:
-        merged = merged.sample(frac=cfg.training.sample_fraction, random_state=cfg.training.random_seed)
+        merged = merged.sample(
+            frac=cfg.training.sample_fraction, random_state=cfg.training.random_seed
+        )
+        logger.info(
+            "Subsampled training data to %.2f%%",
+            cfg.training.sample_fraction * 100,
+        )
+    logger.info("Training dataset shape: %s", merged.shape)
     numeric, categorical = loader.get_feature_lists()
     X = merged[numeric + categorical]
     pipeline = preprocessor.create_preprocessing_pipeline(numeric, categorical)
+    logger.info("Preprocessing pipeline created")
 
     mlflow_cfg = loader.config.mlflow
 
     def train_for_product(product: str) -> None:
+        logger.info("Processing product %s", product)
         y_propensity = merged[f"{cfg.targets.propensity}_{product}"]
         y_revenue = merged[f"{cfg.targets.revenue}_{product}"]
         prop_out = os.path.join(cfg.training.model_dump_path, "propensity", product)
@@ -132,6 +160,7 @@ def main(cfg: DictConfig) -> None:
         os.makedirs(rev_out, exist_ok=True)
 
         if cfg.training.train_enabled:
+            logger.info("Training models for %s", product)
             prop_trainer = PropensityTrainer(
                 model=LogisticRegression(max_iter=200),
                 preprocessor=pipeline,
@@ -153,7 +182,9 @@ def main(cfg: DictConfig) -> None:
                 run_name=f"revenue-{product}",
             )
             rev_trainer.fit(X, y_revenue)
+            logger.info("Finished training models for %s", product)
         else:
+            logger.info("Loading pretrained models for %s", product)
             loader = ModelLoader(config=config_dict)
             loader.load_model("propensity", product)
             loader.load_model("revenue", product)
@@ -161,18 +192,18 @@ def main(cfg: DictConfig) -> None:
     with ThreadPoolExecutor(max_workers=len(cfg.products)) as executor:
         executor.map(train_for_product, cfg.products)
 
-    # ---------- Inference ----------
+    logger.info("Starting inference")
     prop_preds, rev_preds, client_index = run_inference(
         cfg, preprocessor, loader, datasets, config_dict
     )
 
-    # ---------- Optimization ----------
+    logger.info("Starting optimization")
     selection = run_optimization(cfg, prop_preds, rev_preds)
 
-    # ---------- Evaluation ----------
+    logger.info("Starting evaluation")
     run_evaluation(cfg, selection, prop_preds, rev_preds, config_dict)
 
-    # ---------- Save optimized offers ----------
+    logger.info("Saving optimized offers")
     save_offers(cfg, selection, prop_preds, rev_preds, client_index)
 
 


### PR DESCRIPTION
## Summary
- initialize project logger in `main.py`
- add step-by-step logging for training, inference, optimization and saving results

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hydra')*

------
https://chatgpt.com/codex/tasks/task_e_686a5a8e73b083338119da0448580751