### PR TITLE
Add mlflow server health check

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ from src.optimizer import Optimizer
 from src.preprocessor import Preprocessor
 from src.trainer import PropensityTrainer, RevenueTrainer
 from src.logging import get_logger, setup_logging
+from src.mlflow_utils import ensure_mlflow_server
 
 setup_logging()
 logger = get_logger(__name__)
@@ -116,6 +117,7 @@ def save_offers(
 @hydra.main(config_path="conf/", config_name="config")
 def main(cfg: DictConfig) -> None:
     logger.info("Starting main workflow")
+    ensure_mlflow_server(cfg.mlflow, logger=logger)
     config_dict = OmegaConf.to_container(cfg, resolve=True)
     loader = DataLoader(config=config_dict)
     loader.config_loader.base_dir = os.path.join(get_original_cwd(), "conf")

--- a/src/mlflow_utils.py
+++ b/src/mlflow_utils.py
@@ -1,0 +1,44 @@
+"""Utilities for working with MLflow servers."""
+from __future__ import annotations
+
+from typing import Optional
+import logging
+import urllib.request
+import urllib.error
+
+from .config_models import MlflowConfig
+from .logging import get_logger
+
+
+def ensure_mlflow_server(
+    mlflow_config: MlflowConfig,
+    timeout: int = 5,
+    logger: Optional[logging.Logger] = None,
+) -> MlflowConfig:
+    """Ensure MLflow server is reachable, disable if not.
+
+    Args:
+        mlflow_config: MLflow configuration to validate.
+        timeout: Timeout in seconds for the health check request.
+        logger: Optional logger for status messages.
+
+    Returns:
+        The (possibly modified) MLflow configuration.
+    """
+    if logger is None:
+        logger = get_logger(__name__)
+
+    if not mlflow_config.enabled:
+        return mlflow_config
+
+    try:
+        urllib.request.urlopen(mlflow_config.tracking_uri, timeout=timeout)
+        logger.debug("MLflow server %s is reachable", mlflow_config.tracking_uri)
+    except urllib.error.URLError as exc:
+        logger.warning(
+            "MLflow server %s unreachable: %s. Disabling MLflow logging.",
+            mlflow_config.tracking_uri,
+            exc,
+        )
+        mlflow_config.enabled = False
+    return mlflow_config


### PR DESCRIPTION
## Summary
- add utility to ensure MLflow server availability
- disable MLflow tracking when server is unreachable
- use the new check in `main.py`

## Testing
- `uv run -m pytest -q` *(fails: ConfigSchema validation error)*

------
https://chatgpt.com/codex/tasks/task_e_686a60ff5f708333beab65f061adfa0b