### PR TITLE
Configurable models

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -1,4 +1,5 @@
 defaults:
+  - _self_
   - propensity_model: LogisticRegression
   - revenue_model: RandomForest
   - override hydra/sweeper: optuna

--- a/conf/propensity_model/LogisticRegression.yaml
+++ b/conf/propensity_model/LogisticRegression.yaml
@@ -1,4 +1,4 @@
-# @package _global_
+# @package propensity_model
 model:
   name: LogisticRegressionRegressor
   penalty: "l2"

--- a/conf/revenue_model/RandomForest.yaml
+++ b/conf/revenue_model/RandomForest.yaml
@@ -1,4 +1,4 @@
-# @package _global_
+# @package revenue_model
 model:
   name: RandomForestRegressor
   n_estimators: 100

--- a/main.py
+++ b/main.py
@@ -4,8 +4,7 @@ from concurrent.futures import ThreadPoolExecutor
 import hydra
 from hydra.utils import get_original_cwd
 from omegaconf import DictConfig, OmegaConf
-from sklearn.ensemble import RandomForestRegressor
-from sklearn.linear_model import LogisticRegression
+from src.model_factory import create_model
 
 from src.dataloader import DataLoader
 from src.evaluator import Evaluator
@@ -160,8 +159,10 @@ def main(cfg: DictConfig) -> None:
 
         if cfg.training.train_enabled:
             logger.info("Training models for %s", product)
+            prop_model_cfg = loader.config.propensity_model
+            rev_model_cfg = loader.config.revenue_model
             prop_trainer = PropensityTrainer(
-                model=LogisticRegression(max_iter=200),
+                model=create_model(prop_model_cfg),
                 preprocessor=pipeline,
                 scoring=cfg.training.propensity_scoring,
                 cv=cfg.training.k_folds,
@@ -172,7 +173,7 @@ def main(cfg: DictConfig) -> None:
             prop_trainer.fit(X, y_propensity)
 
             rev_trainer = RevenueTrainer(
-                model=RandomForestRegressor(),
+                model=create_model(rev_model_cfg),
                 preprocessor=pipeline,
                 scoring=cfg.training.revenue_scoring,
                 cv=cfg.training.k_folds,

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -4,6 +4,8 @@ import os
 from typing import Dict, Optional
 
 import yaml
+from hydra import compose, initialize_config_dir
+from omegaconf import OmegaConf
 
 from .config_models import ConfigSchema
 from .logging import get_logger
@@ -14,9 +16,12 @@ class ConfigLoader:
 
     def __init__(self, config_path: Optional[str] = None, config: Optional[Dict] = None) -> None:
         if config_path:
-            with open(config_path, "r", encoding="utf-8") as f:
-                config_dict = yaml.safe_load(f)
-            self.base_dir = os.path.dirname(os.path.abspath(config_path))
+            abs_path = os.path.abspath(config_path)
+            self.base_dir = os.path.dirname(abs_path)
+            config_name = os.path.splitext(os.path.basename(abs_path))[0]
+            with initialize_config_dir(version_base=None, config_dir=self.base_dir):
+                cfg = compose(config_name=config_name)
+            config_dict = OmegaConf.to_container(cfg, resolve=True)
         elif config:
             config_dict = config
             self.base_dir = os.getcwd()

--- a/src/config_models.py
+++ b/src/config_models.py
@@ -29,6 +29,13 @@ class DataConfig(BaseModel):
     sheets: List[str]
 
 
+class ModelConfig(BaseModel):
+    """Definition of a model and its hyperparameters."""
+
+    model_config = ConfigDict(extra="allow")
+    model: Dict[str, Any]
+
+
 class TrainingConfig(BaseModel):
     """Configuration for model training."""
 
@@ -64,6 +71,8 @@ class ConfigSchema(BaseModel):
     preprocessing: PreprocessingConfig
     products: List[str]
     targets: Dict[str, str]
+    propensity_model: ModelConfig
+    revenue_model: ModelConfig
     training: TrainingConfig = TrainingConfig()
     mlflow: MlflowConfig = MlflowConfig()
     inference: InferenceConfig = InferenceConfig()

--- a/src/model_factory.py
+++ b/src/model_factory.py
@@ -1,0 +1,41 @@
+"""Utilities for creating models from configuration."""
+from __future__ import annotations
+
+from typing import Dict, Type
+
+from sklearn.linear_model import LogisticRegression
+from sklearn.ensemble import RandomForestRegressor
+from sklearn.base import BaseEstimator
+
+from .config_models import ModelConfig
+
+
+_MODEL_REGISTRY: Dict[str, Type[BaseEstimator]] = {
+    "LogisticRegression": LogisticRegression,
+    "LogisticRegressionRegressor": LogisticRegression,
+    "RandomForestRegressor": RandomForestRegressor,
+}
+
+
+def create_model(cfg: ModelConfig) -> BaseEstimator:
+    """Instantiate a scikit-learn model from ``ModelConfig``.
+
+    Args:
+        cfg: Model configuration with ``name`` and hyperparameters.
+
+    Returns:
+        Instantiated scikit-learn estimator.
+
+    Raises:
+        KeyError: If ``cfg.name`` is not in the registry.
+    """
+
+    params = dict(cfg.model)
+    name = params.pop("name", None)
+    if not name:
+        raise KeyError("Model configuration missing 'name'")
+    try:
+        model_cls = _MODEL_REGISTRY[name]
+    except KeyError as exc:
+        raise KeyError(f"Unknown model name '{name}'") from exc
+    return model_cls(**params)

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1,6 +1,7 @@
 import os
 
 from hydra import compose, initialize_config_dir
+from omegaconf import OmegaConf
 from sklearn.linear_model import LogisticRegression
 from sklearn.ensemble import RandomForestRegressor
 import yaml
@@ -51,8 +52,9 @@ def test_inference_workflow(tmp_path):
         output_dir=rev_dir,
     ).fit(X, y_rev)
 
-    with open(os.path.join(CONFIG_PATH, "config.yaml"), "r", encoding="utf-8") as f:
-        cfg = yaml.safe_load(f)
+    with initialize_config_dir(version_base=None, config_dir=CONFIG_PATH):
+        cfg = compose(config_name="config")
+        cfg = OmegaConf.to_container(cfg, resolve=True)
 
     cfg["training"]["train_enabled"] = False
     cfg["training"]["load_model_path"] = str(tmp_path)


### PR DESCRIPTION
## Summary
- load configuration with Hydra to resolve model selections
- add `ModelConfig` and `create_model()` factory
- support per-model YAML definitions
- use configured models when training
- update inference tests to compose config with Hydra

## Testing
- `PYTHONPATH=$PWD uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a6167f1b88333a10a32818341efd5