### PR TITLE
Dynamic model loading

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -100,6 +100,8 @@ training:
   load_model_path: "./models"
   sample_fraction: 1.0
   train_enabled: true
+  propensity_model: LogisticRegression
+  revenue_model: RandomForest
 
 mlflow:
   enabled: true

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import os
 from typing import Dict, Optional
 
-import yaml
+from hydra import compose, initialize_config_dir
+from omegaconf import OmegaConf
 
 from .config_models import ConfigSchema
 from .logging import get_logger
@@ -14,10 +15,13 @@ class ConfigLoader:
 
     def __init__(self, config_path: Optional[str] = None, config: Optional[Dict] = None) -> None:
         if config_path:
-            with open(config_path, "r", encoding="utf-8") as f:
-                config_dict = yaml.safe_load(f)
-            self.base_dir = os.path.dirname(os.path.abspath(config_path))
-        elif config:
+            base_dir = os.path.dirname(os.path.abspath(config_path))
+            config_name = os.path.splitext(os.path.basename(config_path))[0]
+            with initialize_config_dir(version_base=None, config_dir=base_dir):
+                cfg = compose(config_name=config_name)
+            config_dict = OmegaConf.to_container(cfg, resolve=True)
+            self.base_dir = base_dir
+        elif config is not None:
             config_dict = config
             self.base_dir = os.getcwd()
         else:

--- a/src/config_models.py
+++ b/src/config_models.py
@@ -42,6 +42,8 @@ class TrainingConfig(BaseModel):
     load_model_path: Optional[str] = None
     sample_fraction: float = 1.0
     train_enabled: bool = True
+    propensity_model: str = "LogisticRegression"
+    revenue_model: str = "RandomForest"
 
 
 class MlflowConfig(BaseModel):

--- a/src/model_factory.py
+++ b/src/model_factory.py
@@ -1,0 +1,41 @@
+"""Factory for creating models from configuration."""
+from __future__ import annotations
+
+import importlib
+import os
+from typing import Any, Dict
+
+import yaml
+from sklearn.base import BaseEstimator
+
+
+class ModelFactory:
+    """Create scikit-learn models from config files."""
+
+    MODEL_MAPPING = {
+        "LogisticRegression": "sklearn.linear_model.LogisticRegression",
+        "RandomForest": "sklearn.ensemble.RandomForestRegressor",
+        "RandomForestRegressor": "sklearn.ensemble.RandomForestRegressor",
+    }
+
+    @staticmethod
+    def _instantiate(model_name: str, params: Dict[str, Any]) -> BaseEstimator:
+        if model_name not in ModelFactory.MODEL_MAPPING:
+            raise ValueError(f"Unsupported model '{model_name}'")
+        module_path, class_name = ModelFactory.MODEL_MAPPING[model_name].rsplit(".", 1)
+        module = importlib.import_module(module_path)
+        model_cls = getattr(module, class_name)
+        return model_cls(**params)
+
+    @staticmethod
+    def from_config(model_type: str, model_name: str, base_dir: str) -> BaseEstimator:
+        """Instantiate a model based on YAML configuration."""
+        subdir = f"{model_type}_model"
+        config_path = os.path.join(base_dir, subdir, f"{model_name}.yaml")
+        if not os.path.exists(config_path):
+            raise FileNotFoundError(f"Model config not found: {config_path}")
+        with open(config_path, "r", encoding="utf-8") as f:
+            config = yaml.safe_load(f)
+        params = config.get("model", {})
+        params.pop("name", None)
+        return ModelFactory._instantiate(model_name, params)

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -10,8 +10,10 @@ CONFIG_PATH = os.path.join(os.path.dirname(__file__), "..", "conf")
 def get_loader():
     with initialize_config_dir(version_base=None, config_dir=CONFIG_PATH):
         cfg = compose(config_name="config")
-    config_file = os.path.join(CONFIG_PATH, "config.yaml")
-    return DataLoader(config_path=config_file)
+    config = OmegaConf.to_container(cfg, resolve=True)
+    loader = DataLoader(config=config)
+    loader.config_loader.base_dir = CONFIG_PATH
+    return loader
 
 
 def test_load_configured_sheets():

--- a/tests/test_model_factory.py
+++ b/tests/test_model_factory.py
@@ -1,0 +1,23 @@
+import os
+import pytest
+from sklearn.linear_model import LogisticRegression
+from sklearn.ensemble import RandomForestRegressor
+
+from src.model_factory import ModelFactory
+
+CONFIG_DIR = os.path.join(os.path.dirname(__file__), "..", "conf")
+
+
+def test_load_logistic_regression():
+    model = ModelFactory.from_config("propensity", "LogisticRegression", CONFIG_DIR)
+    assert isinstance(model, LogisticRegression)
+
+
+def test_load_random_forest():
+    model = ModelFactory.from_config("revenue", "RandomForest", CONFIG_DIR)
+    assert isinstance(model, RandomForestRegressor)
+
+
+def test_missing_config(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        ModelFactory.from_config("propensity", "NonExistent", str(tmp_path))

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -11,8 +11,9 @@ CONFIG_PATH = os.path.join(os.path.dirname(__file__), "..", "conf")
 def get_loader_and_preprocessor():
     with initialize_config_dir(version_base=None, config_dir=CONFIG_PATH):
         cfg = compose(config_name="config")
-    config_file = os.path.join(CONFIG_PATH, "config.yaml")
-    loader = DataLoader(config_path=config_file)
+    config = OmegaConf.to_container(cfg, resolve=True)
+    loader = DataLoader(config=config)
+    loader.config_loader.base_dir = CONFIG_PATH
     datasets = loader.load_configured_sheets()
     with_sales, _ = loader.create_sales_data_split(datasets)
     preprocessor = Preprocessor(loader.get_config())

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1,5 +1,6 @@
 import os
 from hydra import compose, initialize_config_dir
+from omegaconf import OmegaConf
 from sklearn.linear_model import LogisticRegression
 from src.dataloader import DataLoader
 from src.preprocessor import Preprocessor
@@ -10,9 +11,10 @@ CONFIG_PATH = os.path.join(os.path.dirname(__file__), "..", "conf")
 
 def get_training_data():
     with initialize_config_dir(version_base=None, config_dir=CONFIG_PATH):
-        compose(config_name="config")
-    config_file = os.path.join(CONFIG_PATH, "config.yaml")
-    loader = DataLoader(config_path=config_file)
+        cfg = compose(config_name="config")
+    config = OmegaConf.to_container(cfg, resolve=True)
+    loader = DataLoader(config=config)
+    loader.config_loader.base_dir = CONFIG_PATH
     datasets = loader.load_configured_sheets()
     with_sales, _ = loader.create_sales_data_split(datasets)
     preprocessor = Preprocessor(loader.get_config())


### PR DESCRIPTION
## Summary
- load config through Hydra when constructing `ConfigLoader`
- expose `propensity_model` and `revenue_model` in `TrainingConfig`
- support `RandomForest` alias in `ModelFactory`
- update unit tests to use composed config
- add tests for `ModelFactory`

## Testing
- `PYTHONPATH=$(pwd) uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a6e338a508333b6becaa013b9915c