### PR TITLE
Handle train_test_split config

### DIFF
--- a/src/config_models.py
+++ b/src/config_models.py
@@ -17,12 +17,20 @@ class CategoricalImputerConfig(BaseModel):
 class OneHotConfig(BaseModel):
     handle_unknown: str = "ignore"
 
+
+class TrainTestSplitConfig(BaseModel):
+    """Configuration for train-test split."""
+
+    test_size: float = 0.2
+    random_state: int = 42
+
 class PreprocessingConfig(BaseModel):
     features: FeaturesConfig
     categorical: Optional[List[str]] = None
     numeric_imputer: NumericImputerConfig = NumericImputerConfig()
     categorical_imputer: CategoricalImputerConfig = CategoricalImputerConfig()
     onehot: OneHotConfig = OneHotConfig()
+    train_test_split: TrainTestSplitConfig = TrainTestSplitConfig()
 
 class DataConfig(BaseModel):
     raw_excel_path: str

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -26,19 +26,26 @@ class Preprocessor:
     def create_model_train_test_split(
         self,
         datasets_with_sales: Dict[str, pd.DataFrame],
-        test_size: float = 0.2,
-        random_state: int = 42,
+        test_size: Optional[float] = None,
+        random_state: Optional[int] = None,
     ) -> Tuple[Dict[str, pd.DataFrame], Dict[str, pd.DataFrame]]:
         """Split datasets with sales data into train and test subsets.
 
         Args:
             datasets_with_sales: Datasets containing clients with recorded sales.
-            test_size: Fraction of clients to reserve for testing.
-            random_state: Deterministic seed for the split.
+            test_size: Fraction of clients to reserve for testing. If ``None``
+                the value from the configuration is used.
+            random_state: Deterministic seed for the split. If ``None`` the
+                value from the configuration is used.
 
         Returns:
             Tuple of dictionaries containing ``*_train`` and ``*_test`` datasets.
         """
+
+        if test_size is None:
+            test_size = self.config.preprocessing.train_test_split.test_size
+        if random_state is None:
+            random_state = self.config.preprocessing.train_test_split.random_state
 
         sales_dataset_key = next(
             (k for k in datasets_with_sales if "Sales_Revenues" in k), None

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -31,6 +31,23 @@ def test_model_train_test_split():
     assert len(test["Sales_Revenues_test"]) == 194
 
 
+def test_model_train_test_split_from_config():
+    """Split parameters should default to config values when not provided."""
+    with initialize_config_dir(version_base=None, config_dir=CONFIG_PATH):
+        cfg = compose(config_name="config")
+    cfg = OmegaConf.to_container(cfg, resolve=True)
+    cfg["data"]["raw_excel_path"] = os.path.join(
+        os.path.dirname(CONFIG_PATH), "data", "raw", "DataScientist_CaseStudy_Dataset.xlsx"
+    )
+    cfg["preprocessing"]["train_test_split"]["test_size"] = 0.25
+    loader = DataLoader(config=cfg)
+    datasets = loader.load_configured_sheets()
+    with_sales, _ = loader.create_sales_data_split(datasets)
+    preprocessor = Preprocessor(loader.get_config())
+    train, test = preprocessor.create_model_train_test_split(with_sales)
+    assert len(test["Sales_Revenues_test"]) == 243
+
+
 def test_merge_datasets():
     """Ensure datasets merge correctly on the Client key."""
     loader, preprocessor, with_sales = get_loader_and_preprocessor()


### PR DESCRIPTION
## Summary
- add `TrainTestSplitConfig` to configuration schema
- default `create_model_train_test_split` to use config values
- test that splitting uses config settings

## Testing
- `pytest tests/test_preprocessor.py::test_model_train_test_split_from_config -q`
- `pytest tests/test_preprocessor.py -q`
- `pytest tests/test_evaluator_optimizer.py::test_optimizer_simple -q`

------
https://chatgpt.com/codex/tasks/task_e_686a85c7d0a883339f0debe546416383