### PR TITLE
Ensure client IDs are stored with inference results

### DIFF
--- a/main.py
+++ b/main.py
@@ -38,6 +38,7 @@ def run_inference(
     numeric, categorical = loader.get_feature_lists()
     X_inf = inference_df[numeric + categorical]
     X_inf.index = inference_df["Client"]
+    X_inf.index.name = "Client"
 
     logger.info("Running propensity and revenue inference")
     prop_inf = PropensityInference(config=config_dict)

--- a/src/inference.py
+++ b/src/inference.py
@@ -41,9 +41,9 @@ class BaseInference(ABC):
         return results
 
     def save(self, df: pd.DataFrame, filename: str) -> str:
-        """Persist predictions to CSV."""
+        """Persist predictions to CSV with client identifiers."""
         path = os.path.join(self.output_dir, filename)
-        df.to_csv(path, index=False)
+        df.to_csv(path, index_label="Client")
         self.logger.info("Saved inference results to %s", path)
         return path
 

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -2,6 +2,7 @@ import os
 
 from hydra import compose, initialize_config_dir
 from omegaconf import OmegaConf
+import pandas as pd
 from sklearn.linear_model import LogisticRegression
 from sklearn.ensemble import RandomForestRegressor
 
@@ -76,6 +77,12 @@ def test_inference_workflow(tmp_path):
 
     assert os.path.exists(prop_path)
     assert os.path.exists(rev_path)
+    prop_df = pd.read_csv(prop_path)
+    rev_df = pd.read_csv(rev_path)
+    assert "Client" in prop_df.columns
+    assert "Client" in rev_df.columns
+    assert prop_df.shape[0] == X.shape[0]
+    assert rev_df.shape[0] == X.shape[0]
     assert prop_preds.shape[0] == X.shape[0]
     assert rev_preds.shape[0] == X.shape[0]
     assert (prop_preds > 0).all().all()


### PR DESCRIPTION
## Summary
- keep client index name when preparing inference data
- save inference outputs with a `Client` column
- check for `Client` column in inference tests

## Testing
- `uv run -m pytest -q`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_686a8ce1ab6483338e34fbf967565737