### PR TITLE
Enhance evaluator structure

### DIFF
--- a/src/metrics.py
+++ b/src/metrics.py
@@ -78,3 +78,94 @@ METRIC_REGISTRY: Dict[str, Type[Metric]] = {
     AcceptanceRateMetric.name: AcceptanceRateMetric,
     ROIMetric.name: ROIMetric,
 }
+
+
+class ModelMetric(ABC):
+    """Base class for model evaluation metrics."""
+
+    name: str
+
+    @abstractmethod
+    def compute(self, y_true: np.ndarray, y_pred: np.ndarray) -> float:
+        """Compute metric value."""
+
+
+class PrecisionMetric(ModelMetric):
+    """Precision for binary classification."""
+
+    name = "precision"
+
+    def compute(self, y_true: np.ndarray, y_pred: np.ndarray) -> float:
+        from sklearn.metrics import precision_score
+
+        return float(precision_score(y_true, y_pred))
+
+
+class RecallMetric(ModelMetric):
+    """Recall for binary classification."""
+
+    name = "recall"
+
+    def compute(self, y_true: np.ndarray, y_pred: np.ndarray) -> float:
+        from sklearn.metrics import recall_score
+
+        return float(recall_score(y_true, y_pred))
+
+
+class F1Metric(ModelMetric):
+    """F1 score for binary classification."""
+
+    name = "f1"
+
+    def compute(self, y_true: np.ndarray, y_pred: np.ndarray) -> float:
+        from sklearn.metrics import f1_score
+
+        return float(f1_score(y_true, y_pred))
+
+
+class R2Metric(ModelMetric):
+    """Coefficient of determination for regression."""
+
+    name = "r2"
+
+    def compute(self, y_true: np.ndarray, y_pred: np.ndarray) -> float:
+        from sklearn.metrics import r2_score
+
+        return float(r2_score(y_true, y_pred))
+
+
+class AdjustedR2Metric(ModelMetric):
+    """Adjusted :math:`R^2` taking number of features into account."""
+
+    name = "adjusted_r2"
+
+    def __init__(self, n_features: int) -> None:
+        self.n_features = n_features
+
+    def compute(self, y_true: np.ndarray, y_pred: np.ndarray) -> float:
+        from sklearn.metrics import r2_score
+
+        r2 = r2_score(y_true, y_pred)
+        n = len(y_true)
+        return float(1 - (1 - r2) * (n - 1) / (n - self.n_features - 1))
+
+
+class RMSEMetric(ModelMetric):
+    """Root mean squared error for regression."""
+
+    name = "rmse"
+
+    def compute(self, y_true: np.ndarray, y_pred: np.ndarray) -> float:
+        from sklearn.metrics import mean_squared_error
+
+        return float(mean_squared_error(y_true, y_pred, squared=False))
+
+
+MODEL_METRIC_REGISTRY: Dict[str, Type[ModelMetric]] = {
+    PrecisionMetric.name: PrecisionMetric,
+    RecallMetric.name: RecallMetric,
+    F1Metric.name: F1Metric,
+    R2Metric.name: R2Metric,
+    AdjustedR2Metric.name: AdjustedR2Metric,
+    RMSEMetric.name: RMSEMetric,
+}

--- a/src/model_evaluator.py
+++ b/src/model_evaluator.py
@@ -1,0 +1,111 @@
+"""Model evaluation utilities for training workflows."""
+from __future__ import annotations
+
+import os
+from typing import Dict, Optional, Sequence, List
+
+import matplotlib.pyplot as plt
+from sklearn.metrics import ConfusionMatrixDisplay, confusion_matrix
+
+from .logging import get_logger
+from .metrics import (
+    MODEL_METRIC_REGISTRY,
+    ModelMetric,
+    PrecisionMetric,
+    RecallMetric,
+    F1Metric,
+    R2Metric,
+    AdjustedR2Metric,
+    RMSEMetric,
+)
+from .mlflow_utils import MlflowConfig
+import mlflow
+
+
+class BaseModelEvaluator:
+    """Common logic for model evaluators."""
+
+    def __init__(
+        self,
+        metrics: Sequence[str | ModelMetric],
+        mlflow_config: Optional[MlflowConfig] = None,
+        run_name: Optional[str] = None,
+        artifact_dir: Optional[str] = None,
+    ) -> None:
+        self.metrics: List[ModelMetric] = [self._resolve(m) for m in metrics]
+        self.mlflow_config = mlflow_config
+        self.run_name = run_name
+        self.artifact_dir = artifact_dir
+        self.logger = get_logger(self.__class__.__name__)
+
+    def _resolve(self, metric: str | ModelMetric) -> ModelMetric:
+        if isinstance(metric, ModelMetric):
+            return metric
+        metric_cls = MODEL_METRIC_REGISTRY[metric]
+        return metric_cls()  # type: ignore[return-value]
+
+    def _log(self, values: Dict[str, float], artifacts: Sequence[str] | None = None) -> None:
+        if self.mlflow_config and self.mlflow_config.enabled:
+            with mlflow.start_run(run_name=self.run_name):
+                mlflow.log_metrics(values)
+                if artifacts:
+                    for art in artifacts:
+                        mlflow.log_artifact(art, artifact_path="plots")
+
+
+class ClassifierEvaluator(BaseModelEvaluator):
+    """Evaluate classification models and log metrics."""
+
+    def __init__(
+        self,
+        threshold: float = 0.5,
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            metrics=[PrecisionMetric.name, RecallMetric.name, F1Metric.name],
+            **kwargs,
+        )
+        self.threshold = threshold
+
+    def evaluate(self, model, X, y) -> Dict[str, float]:
+        if hasattr(model, "predict_proba"):
+            prob = model.predict_proba(X)[:, 1]
+        else:
+            prob = model.predict(X)
+        preds = (prob >= self.threshold).astype(int)
+        values = {m.name: m.compute(y, preds) for m in self.metrics}
+
+        plot_path = None
+        if self.artifact_dir:
+            cm = confusion_matrix(y, preds)
+            disp = ConfusionMatrixDisplay(confusion_matrix=cm)
+            disp.plot()
+            plot_path = os.path.join(self.artifact_dir, "test_confusion_matrix.png")
+            plt.savefig(plot_path)
+            plt.close()
+
+        self._log(values, [plot_path] if plot_path else None)
+        return values
+
+
+class RegressorEvaluator(BaseModelEvaluator):
+    """Evaluate regression models and log metrics."""
+
+    def __init__(self, n_features: int, **kwargs) -> None:
+        super().__init__(
+            metrics=[R2Metric.name, AdjustedR2Metric.name, RMSEMetric.name],
+            **kwargs,
+        )
+        self.n_features = n_features
+
+    def _resolve(self, metric: str | ModelMetric) -> ModelMetric:
+        if metric == AdjustedR2Metric.name:
+            return AdjustedR2Metric(self.n_features)
+        return super()._resolve(metric)
+
+    def evaluate(self, model, X, y) -> Dict[str, float]:
+        preds = model.predict(X)
+        values = {m.name: m.compute(y, preds) for m in self.metrics}
+        self._log(values)
+        return values
+

--- a/src/trainer.py
+++ b/src/trainer.py
@@ -99,8 +99,9 @@ class Trainer(BaseTrainer):
                 scoring=self.scoring,
                 return_train_score=True,
             )
-            self.train_score = float(cv_results["train_score"].mean())
-            self.test_score = float(cv_results["test_score"].mean())
+            sign = -1.0 if str(self.scoring).startswith("neg_") else 1.0
+            self.train_score = float(cv_results["train_score"].mean() * sign)
+            self.test_score = float(cv_results["test_score"].mean() * sign)
             self.logger.info(
                 "Cross validation completed: train_score=%.4f, test_score=%.4f",
                 self.train_score,


### PR DESCRIPTION
## Summary
- add RMSE metric and class-based evaluators
- refactor training workflow to use evaluator classes for metrics and MLflow logging
- compute metrics via new evaluators and keep `main` functions short

## Testing
- `ruff check .`
- `uv run -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686a84c6b83c8333976b4fb6d73ecce4