### PR TITLE
Add dataset split saving feature

### DIFF
--- a/src/config_models.py
+++ b/src/config_models.py
@@ -39,6 +39,8 @@ class PreprocessingConfig(BaseModel):
     categorical_imputer: CategoricalImputerConfig = CategoricalImputerConfig()
     onehot: OneHotConfig = OneHotConfig()
     train_test_split: TrainTestSplitConfig = TrainTestSplitConfig()
+    enable_save: bool = False
+    save_path: str = "./preprocessed"
 
 class DataConfig(BaseModel):
     raw_excel_path: str

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1,4 +1,5 @@
 import os
+import pandas as pd
 
 from hydra import compose, initialize_config_dir
 from omegaconf import OmegaConf
@@ -21,6 +22,7 @@ def prepare_data():
     cfg["data"]["raw_excel_path"] = os.path.join(
         os.path.dirname(CONFIG_PATH), "data", "raw", "DataScientist_CaseStudy_Dataset.xlsx"
     )
+    cfg["preprocessing"]["enable_save"] = False
     loader = DataLoader(config=cfg)
     datasets = loader.load_configured_sheets()
     preprocessor = Preprocessor(loader.get_config())

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -17,6 +17,7 @@ def get_training_data():
     cfg["data"]["raw_excel_path"] = os.path.join(
         os.path.dirname(CONFIG_PATH), "data", "raw", "DataScientist_CaseStudy_Dataset.xlsx"
     )
+    cfg["preprocessing"]["enable_save"] = False
     loader = DataLoader(config=cfg)
     datasets = loader.load_configured_sheets()
     with_sales, _ = loader.create_sales_data_split(datasets)


### PR DESCRIPTION
## Summary
- extend preprocessing config with save options
- add optional CSV export after train-test split
- ensure unit tests disable saving by default
- add test for the new save feature

## Testing
- `ruff check . --fix`
- `.venv/bin/python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a96406fa08333911528fb4f59b540