### PR TITLE
Improve Streamlit dashboards

### DIFF
--- a/pages/2_propensity.py
+++ b/pages/2_propensity.py
@@ -22,6 +22,9 @@ if not run_dir:
 
 st.header("Propensity Models")
 prop, _ = load_predictions(run_dir)
+if prop is None:
+    st.warning("Propensity predictions not found.")
+    st.stop()
 test_df = load_test_data(run_dir)
 model_root = os.path.join(run_dir, "models", "propensity")
 products = list_products(model_root)
@@ -39,11 +42,12 @@ for product in products:
         )
         st.pyplot(cm.figure_)
     model_dir = os.path.join(model_root, product)
-    joblibs = [f for f in os.listdir(model_dir) if f.endswith(".joblib")]
-    if joblibs:
-        fi = get_feature_importance(os.path.join(model_dir, joblibs[0]))
-        if fi is not None:
-            st.bar_chart(fi)
-    meta = load_metadata(model_dir)
-    if meta:
-        st.json(meta)
+    if os.path.exists(model_dir):
+        joblibs = [f for f in os.listdir(model_dir) if f.endswith(".joblib")]
+        if joblibs:
+            fi = get_feature_importance(os.path.join(model_dir, joblibs[0]))
+            if fi is not None:
+                st.bar_chart(fi)
+        meta = load_metadata(model_dir)
+        if meta:
+            st.json(meta)

--- a/pages/3_revenue.py
+++ b/pages/3_revenue.py
@@ -20,6 +20,9 @@ if not run_dir:
 
 st.header("Revenue Models")
 _, rev = load_predictions(run_dir)
+if rev is None:
+    st.warning("Revenue predictions not found.")
+    st.stop()
 test_df = load_test_data(run_dir)
 model_root = os.path.join(run_dir, "models", "revenue")
 products = list_products(model_root)
@@ -33,11 +36,12 @@ for product in products:
         metrics = regression_metrics(y_true, y_pred)
         st.write(pd.DataFrame(metrics, index=[0]))
     model_dir = os.path.join(model_root, product)
-    joblibs = [f for f in os.listdir(model_dir) if f.endswith(".joblib")]
-    if joblibs:
-        fi = get_feature_importance(os.path.join(model_dir, joblibs[0]))
-        if fi is not None:
-            st.bar_chart(fi)
-    meta = load_metadata(model_dir)
-    if meta:
-        st.json(meta)
+    if os.path.exists(model_dir):
+        joblibs = [f for f in os.listdir(model_dir) if f.endswith(".joblib")]
+        if joblibs:
+            fi = get_feature_importance(os.path.join(model_dir, joblibs[0]))
+            if fi is not None:
+                st.bar_chart(fi)
+        meta = load_metadata(model_dir)
+        if meta:
+            st.json(meta)

--- a/pages/4_evaluation.py
+++ b/pages/4_evaluation.py
@@ -25,6 +25,9 @@ if not os.path.exists(results_file):
 
 offers = pd.read_csv(results_file)
 prop, rev = load_predictions(run_dir)
+if prop is None or rev is None:
+    st.warning("Prediction files not found.")
+    st.stop()
 
 st.header("Evaluation")
 

--- a/pages/5_client_list.py
+++ b/pages/5_client_list.py
@@ -18,4 +18,5 @@ if not os.path.exists(results_file):
 offers = pd.read_csv(results_file)
 
 st.header("Optimized Client List")
-st.dataframe(offers)
+max_rows = st.number_input("Rows to display", min_value=1, max_value=len(offers), value=min(20, len(offers)))
+st.dataframe(offers.head(int(max_rows)))

--- a/src/streamlit_utils.py
+++ b/src/streamlit_utils.py
@@ -30,12 +30,17 @@ def list_run_directories(base_dir: str = BASE_OUTPUT_DIR) -> List[str]:
     return sorted(p for p in glob.glob(pattern) if os.path.isdir(p))
 
 
-def load_predictions(run_dir: str) -> Tuple[pd.DataFrame, pd.DataFrame]:
-    """Load propensity and revenue predictions for a run."""
+def load_predictions(run_dir: str) -> Tuple[pd.DataFrame | None, pd.DataFrame | None]:
+    """Load propensity and revenue predictions for a run.
+
+    Missing files are ignored and ``None`` is returned instead of raising an
+    exception.
+    """
     prop_path = os.path.join(run_dir, "inference", "propensity_predictions.csv")
     rev_path = os.path.join(run_dir, "inference", "revenue_predictions.csv")
-    prop = pd.read_csv(prop_path, index_col="Client")
-    rev = pd.read_csv(rev_path, index_col="Client")
+
+    prop = pd.read_csv(prop_path, index_col="Client") if os.path.exists(prop_path) else None
+    rev = pd.read_csv(rev_path, index_col="Client") if os.path.exists(rev_path) else None
     return prop, rev
 
 


### PR DESCRIPTION
## Summary
- make `load_predictions` resilient to missing files
- handle missing predictions gracefully in Streamlit pages
- guard against missing model directories in visualizations
- allow limiting rows displayed in the optimized client list

## Testing
- `ruff check .`
- `PYTHONPATH=. uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b6ffdb68c83339581baa8d44218f0