### PR TITLE
Enhance Streamlit dashboard

### DIFF
--- a/pages/0_summary.py
+++ b/pages/0_summary.py
@@ -1,0 +1,31 @@
+"""Overview of all runs."""
+from __future__ import annotations
+
+import streamlit as st
+from src.streamlit_utils import summarize_runs
+
+st.header("Run Summary")
+summary_df = summarize_runs()
+if summary_df.empty:
+    st.info("No run directories found in 'outputs'.")
+    st.stop()
+
+st.dataframe(summary_df)
+
+best_rev = summary_df.loc[summary_df["total_revenue"].idxmax()]
+st.subheader("Best Expected Revenue")
+st.write(f"{best_rev['run']} - {best_rev['total_revenue']:.2f}")
+
+best_prob = summary_df.loc[summary_df["mean_probability"].idxmax()]
+st.subheader("Best Average Probability")
+st.write(f"{best_prob['run']} - {best_prob['mean_probability']:.4f}")
+
+best_train = summary_df.loc[summary_df["best_train_score"].idxmax()]
+st.subheader("Best Train Score")
+st.write(f"{best_train['run']} - {best_train['best_train_score']:.4f}")
+
+best_test = summary_df.loc[summary_df["best_test_score"].idxmax()]
+st.subheader("Best Test Score")
+st.write(f"{best_test['run']} - {best_test['best_test_score']:.4f}")
+
+st.bar_chart(summary_df.set_index("run")[["total_revenue", "mean_probability"]])

--- a/pages/1_filter.py
+++ b/pages/1_filter.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 import streamlit as st
-from src.streamlit_utils import list_run_directories
+import os
+import pandas as pd
+from src.streamlit_utils import list_run_directories, list_products, load_metadata
 
 st.header("Select Output Folder")
 run_dirs = list_run_directories()
@@ -15,3 +17,20 @@ else:
     choice = st.selectbox("Available runs", run_dirs, index=idx)
     st.session_state["run_dir"] = choice
     st.write(f"Current selection: {choice}")
+
+    prop_root = os.path.join(choice, "models", "propensity")
+    rev_root = os.path.join(choice, "models", "revenue")
+    model_rows = []
+    for model_type, root_dir in [("propensity", prop_root), ("revenue", rev_root)]:
+        products = list_products(root_dir)
+        for product in products:
+            meta = load_metadata(os.path.join(root_dir, product))
+            model_rows.append({
+                "Model type": model_type,
+                "Product": product,
+                "Model": meta.get("model_name", "N/A"),
+            })
+
+    if model_rows:
+        st.subheader("Models Used")
+        st.table(pd.DataFrame(model_rows))

--- a/pages/2_propensity.py
+++ b/pages/2_propensity.py
@@ -27,9 +27,7 @@ if prop is None:
     st.stop()
 test_df = load_test_data(run_dir)
 model_root = os.path.join(run_dir, "models", "propensity")
-print (f"Model root: {model_root}")
 products = list_products(model_root)
-print (f"Products: {products}")
 
 for product in products:
     st.subheader(product)
@@ -52,11 +50,17 @@ for product in products:
         st.pyplot(cm.figure_)
     model_dir = os.path.join(model_root, product)
     if os.path.exists(model_dir):
+        meta = load_metadata(model_dir)
+        if meta:
+            st.markdown(f"**Model:** {meta.get('model_name', 'Unknown')}")
+            st.write(
+                {
+                    "train_score": meta.get("train_score"),
+                    "test_score": meta.get("test_score"),
+                }
+            )
         joblibs = [f for f in os.listdir(model_dir) if f.endswith(".joblib")]
         if joblibs:
             fi = get_feature_importance(os.path.join(model_dir, joblibs[0]))
             if fi is not None:
-                st.bar_chart(fi)
-        meta = load_metadata(model_dir)
-        if meta:
-            st.json(meta)
+                st.bar_chart(fi.sort_values(ascending=False))

--- a/pages/3_revenue.py
+++ b/pages/3_revenue.py
@@ -45,11 +45,17 @@ for product in products:
         st.write(pd.DataFrame(metrics, index=[0]))
     model_dir = os.path.join(model_root, product)
     if os.path.exists(model_dir):
+        meta = load_metadata(model_dir)
+        if meta:
+            st.markdown(f"**Model:** {meta.get('model_name', 'Unknown')}")
+            st.write(
+                {
+                    "train_score": meta.get("train_score"),
+                    "test_score": meta.get("test_score"),
+                }
+            )
         joblibs = [f for f in os.listdir(model_dir) if f.endswith(".joblib")]
         if joblibs:
             fi = get_feature_importance(os.path.join(model_dir, joblibs[0]))
             if fi is not None:
-                st.bar_chart(fi)
-        meta = load_metadata(model_dir)
-        if meta:
-            st.json(meta)
+                st.bar_chart(fi.sort_values(ascending=False))


### PR DESCRIPTION
## Summary
- add summary dashboard page for all runs
- display models used on the Filter page
- show model metadata in propensity and revenue pages
- sort feature importance and clean up output
- utility helpers to aggregate run metrics

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_686b7e249e5083339f7d6d2a2a0f1613