### PR TITLE
Add evaluation metric saving

### DIFF
--- a/main.py
+++ b/main.py
@@ -68,7 +68,10 @@ def run_evaluation(
     rev_preds: pd.DataFrame,
     config_dict: dict,
 ) -> dict:
-    """Evaluate optimized offers using configured metrics."""
+    """Evaluate optimized offers using configured metrics.
+
+    Metrics are persisted when ``cfg.evaluation.save_path`` is provided.
+    """
     logger.info("Evaluating optimization results")
     evaluator = Evaluator(
         config=config_dict, cost_per_contact=cfg.evaluation.cost_per_contact
@@ -76,6 +79,8 @@ def run_evaluation(
     results = evaluator.evaluate(selection, prop_preds.values, rev_preds.values)
     for name, value in results.items():
         logger.info("%s: %.4f", name, value)
+    if cfg.evaluation.save_path:
+        evaluator.save(results, cfg.evaluation.save_path)
     return results
 
 

--- a/src/evaluator.py
+++ b/src/evaluator.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 
 from typing import Dict, Iterable, List, Optional, Sequence
 
+import os
+import pandas as pd
+
 import numpy as np
 
 from .config_models import ConfigSchema
@@ -83,5 +86,21 @@ class Evaluator:
         for metric in self.metrics:
             results[metric.name] = metric.compute(selection, propensity, revenue)
         return results
+
+    def save(self, results: Dict[str, float], path: str) -> str:
+        """Persist evaluation metrics to a CSV file.
+
+        Args:
+            results: Mapping of metric names to computed values.
+            path: Destination CSV file path.
+
+        Returns:
+            The absolute path to the saved metrics file.
+        """
+        abs_path = os.path.abspath(path)
+        os.makedirs(os.path.dirname(abs_path), exist_ok=True)
+        pd.DataFrame([results]).to_csv(abs_path, index=False)
+        self.logger.info("Saved evaluation metrics to %s", abs_path)
+        return abs_path
 
 

--- a/tests/test_evaluator_optimizer.py
+++ b/tests/test_evaluator_optimizer.py
@@ -36,6 +36,24 @@ def test_evaluator_metrics():
     assert results["roi"] == pytest.approx(expected_total / (2 * 2.0))
 
 
+def test_evaluator_save(tmp_path):
+    """Evaluator should persist metrics to the specified CSV file."""
+    selection = np.array([[1]])
+    propensity = np.array([[0.5]])
+    revenue = np.array([[100]])
+    evaluator = Evaluator(
+        config=None,
+        metrics=[TotalRevenueMetric()],
+        cost_per_contact=1.0,
+    )
+    results = evaluator.evaluate(selection, propensity, revenue)
+    path = tmp_path / "metrics.csv"
+    saved_path = evaluator.save(results, str(path))
+    assert saved_path == str(path.resolve())
+    saved = np.genfromtxt(saved_path, delimiter=",", names=True, dtype=None, encoding="utf-8")
+    assert saved["total_revenue"] == pytest.approx(50.0)
+
+
 @pytest.mark.skipif("ECOS_BB" not in cp.installed_solvers(), reason="ECOS_BB solver not available")
 def test_optimizer_simple():
     """Optimizer should respect contact limit and one-off constraints."""


### PR DESCRIPTION
## Summary
- provide a `save` method in `Evaluator`
- persist metrics in `main.run_evaluation`
- test metric saving

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686b6b79ee1c8333b76d390f011c54ba