### PR TITLE
Add configurable collinearity filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ This setup mirrors a real-world scenario where a bank must allocate limited mark
 - **Interactive Dashboard** – comprehensive Streamlit web interface
 - **Optimization Engine** – mathematical optimization to maximize revenue under constraints
 - **Configurable Pipeline** – Hydra-based configuration management
+- **Collinearity Filtering** – optional removal of highly correlated features
 - **Comprehensive Testing** – full test suite with pytest
 - **Containerized Deployment** – Docker support for easy deployment
 

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -69,6 +69,10 @@ preprocessing:
     random_state: ${seed}
   enable_save: true
   save_path: "./preprocessed"
+  collinearity_filter:
+    enabled: false
+    corr_threshold: 0.8
+    vif_threshold: 5.0
 
 optimization:
   contact_limit: 100

--- a/main.py
+++ b/main.py
@@ -29,14 +29,28 @@ def run_inference(
     loader: DataLoader,
     datasets: dict,
     config_dict: dict,
+    numeric_features: list[str],
+    categorical_features: list[str],
 ) -> tuple[pd.DataFrame, pd.DataFrame, pd.Index]:
-    """Run propensity and revenue inference."""
+    """Run propensity and revenue inference.
+
+    Args:
+        cfg: Hydra configuration object.
+        preprocessor: Instance used to merge datasets.
+        loader: DataLoader with project configuration.
+        datasets: Raw datasets to merge for inference.
+        config_dict: Configuration dictionary for inference objects.
+        numeric_features: Numeric feature list used during training.
+        categorical_features: Categorical feature list used during training.
+
+    Returns:
+        Tuple of propensity predictions, revenue predictions, and client index.
+    """
     logger.info("Merging datasets for inference")
     inference_df = preprocessor.merge_datasets(
         datasets, base_dataset_key="Sales_Revenues"
     )
-    numeric, categorical = loader.get_feature_lists()
-    X_inf = inference_df[numeric + categorical]
+    X_inf = inference_df[numeric_features + categorical_features]
     X_inf.index = inference_df["Client"]
     X_inf.index.name = "Client"
 
@@ -153,6 +167,16 @@ def main(cfg: DictConfig) -> None:
         )
     logger.info("Training dataset shape: %s", merged.shape)
     numeric, categorical = loader.get_feature_lists()
+    if (
+        cfg.preprocessing.collinearity_filter.enabled
+        and (
+            "linear_model" in cfg.propensity_model._target_
+            or "linear_model" in cfg.revenue_model._target_
+        )
+    ):
+        numeric = preprocessor.remove_multicollinearity(
+            merged, numeric
+        )
     X = merged[numeric + categorical]
     pipeline = preprocessor.create_preprocessing_pipeline(numeric, categorical)
     logger.info("Preprocessing pipeline created")
@@ -204,7 +228,13 @@ def main(cfg: DictConfig) -> None:
 
     logger.info("Starting inference")
     prop_preds, rev_preds, client_index = run_inference(
-        cfg, preprocessor, loader, datasets, config_dict
+        cfg,
+        preprocessor,
+        loader,
+        datasets,
+        config_dict,
+        numeric,
+        categorical,
     )
 
     logger.info("Starting optimization")

--- a/src/config_models.py
+++ b/src/config_models.py
@@ -30,6 +30,14 @@ class OneHotConfig(BaseModel):
     handle_unknown: str = "ignore"
 
 
+class CollinearityFilterConfig(BaseModel):
+    """Settings for multicollinearity removal."""
+
+    enabled: bool = False
+    corr_threshold: float = 0.8
+    vif_threshold: float = 5.0
+
+
 class TrainTestSplitConfig(BaseModel):
     """Configuration for train-test split."""
 
@@ -46,6 +54,7 @@ class PreprocessingConfig(BaseModel):
     train_test_split: TrainTestSplitConfig = TrainTestSplitConfig()
     enable_save: bool = False
     save_path: str = "./preprocessed"
+    collinearity_filter: CollinearityFilterConfig = CollinearityFilterConfig()
 
 
 class DataConfig(BaseModel):

--- a/src/inference.py
+++ b/src/inference.py
@@ -79,4 +79,6 @@ class RevenueInference(BaseInference):
     output_prefix = "expected_revenue"
 
     def _predict(self, model, X: pd.DataFrame) -> pd.Series:
-        return pd.Series(model.predict(X), index=X.index)
+        preds = pd.Series(model.predict(X), index=X.index)
+        preds[preds < 0] = 0.0
+        return preds

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -104,3 +104,18 @@ def test_train_test_split_saved(tmp_path):
     train_df = pd.read_csv(train_path)
     test_df = pd.read_csv(test_path)
     assert set(train_df.columns) == set(test_df.columns)
+
+
+def test_remove_multicollinearity():
+    """Numeric features should be reduced when thresholds are low."""
+    loader, preprocessor, with_sales = get_loader_and_preprocessor()
+    train, _ = preprocessor.create_model_train_test_split(with_sales)
+    merged = preprocessor.merge_datasets(
+        train, base_dataset_key="Sales_Revenues_train"
+    )
+    numeric, _ = loader.get_feature_lists()
+    filtered = preprocessor.remove_multicollinearity(
+        merged, numeric, corr_threshold=0.1, vif_threshold=1.0
+    )
+    assert set(filtered).issubset(set(numeric))
+    assert len(filtered) < len(numeric)


### PR DESCRIPTION
## Summary
- add `collinearity_filter` settings to preprocessing config
- implement `remove_multicollinearity` helper in `Preprocessor`
- drop highly correlated/VIF features when enabled for linear models
- clip negative revenue predictions to zero in inference
- update README with new feature
- test multicollinearity removal

## Testing
- `ruff check .`
- `PYTHONPATH=. uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ca3228174833384e0c583b2da0356